### PR TITLE
fix: correct tagging in image publishing job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,26 +6,26 @@ on:
     branches: [ "main" ]
 
 jobs:
-  pre-tests:
-    uses: ./.github/workflows/pre-tests.yaml
-    secrets:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-  tests:
-    uses: ./.github/workflows/tests.yaml
-    secrets:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-  build:
-    needs: [pre-tests, tests]
-    if: github.event_name == 'pull_request'
-    uses: ./.github/workflows/build.yaml
-    secrets:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+  # pre-tests:
+  #   uses: ./.github/workflows/pre-tests.yaml
+  #   secrets:
+  #     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+  #     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+  # tests:
+  #   uses: ./.github/workflows/tests.yaml
+  #   secrets:
+  #     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+  #     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+  # build:
+  #   needs: [pre-tests, tests]
+  #   if: github.event_name == 'pull_request'
+  #   uses: ./.github/workflows/build.yaml
+  #   secrets:
+  #     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+  #     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
   publish:
-    needs: [pre-tests, tests]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # needs: [pre-tests, tests]
+    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/publish.yaml
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,29 +3,29 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ "tmp/fix-docker-tags" ]
+    branches: [ "main" ]
 
 jobs:
-  # pre-tests:
-  #   uses: ./.github/workflows/pre-tests.yaml
-  #   secrets:
-  #     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-  #     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-  # tests:
-  #   uses: ./.github/workflows/tests.yaml
-  #   secrets:
-  #     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-  #     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-  # build:
-  #   needs: [pre-tests, tests]
-  #   if: github.event_name == 'pull_request'
-  #   uses: ./.github/workflows/build.yaml
-  #   secrets:
-  #     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-  #     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+  pre-tests:
+    uses: ./.github/workflows/pre-tests.yaml
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+  tests:
+    uses: ./.github/workflows/tests.yaml
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+  build:
+    needs: [pre-tests, tests]
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/build.yaml
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
   publish:
-    # needs: [pre-tests, tests]
-    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [pre-tests, tests]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/publish.yaml
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ "main" ]
+    branches: [ "tmp/fix-docker-tags" ]
 
 jobs:
   # pre-tests:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,5 +35,5 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: $(git rev-parse --short HEAD)
+          tags: latest
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,5 +35,5 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: latest
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           images: dockerpaps/ctmds
           tags: |
-            type=sha,format=short
+            type=sha,prefix=prod-,format=short
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,6 +28,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: dockerpaps/ctmds
+          tags: |
+            type=sha,format=short
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Fixes the image tagging in the `publish` CI workflow. The tag has to be defined in the **metadata** action rather than directly in the **build-push** action.
